### PR TITLE
Add error for gegenbauer with lambda=0

### DIFF
--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -25,25 +25,30 @@ names = [
 ]
 
 recs = {
-    "leg": (orthax.recurrence.Legendre, ()),
-    "sleg": (orthax.recurrence.ShiftedLegendre, ()),
-    "chebT": (orthax.recurrence.ChebyshevT, ()),
-    "chebU": (orthax.recurrence.ChebyshevU, ()),
-    "chebV": (orthax.recurrence.ChebyshevV, ()),
-    "chebW": (orthax.recurrence.ChebyshevW, ()),
-    "geg": (orthax.recurrence.Gegenbauer, (0.23,)),
-    "jac": (orthax.recurrence.Jacobi, (-0.27, 0.64)),
-    "lag": (orthax.recurrence.Laguerre, ()),
-    "glag": (orthax.recurrence.GeneralizedLaguerre, (2.5,)),
-    "herm": (orthax.recurrence.Hermite, ()),
-    "herme": (orthax.recurrence.HermiteE, ()),
+    "leg": (orthax.recurrence.Legendre, (), 1e-12),
+    "sleg": (orthax.recurrence.ShiftedLegendre, (), 1e-12),
+    "chebT": (orthax.recurrence.ChebyshevT, (), 1e-8),
+    "chebU": (orthax.recurrence.ChebyshevU, (), 1e-8),
+    "chebV": (orthax.recurrence.ChebyshevV, (), 1e-8),
+    "chebW": (orthax.recurrence.ChebyshevW, (), 1e-8),
+    "jac_pp": (orthax.recurrence.Jacobi, (0.27, 0.27), 1e-8),
+    "jac_pn": (orthax.recurrence.Jacobi, (0.27, -0.27), 1e-8),
+    "jac_np": (orthax.recurrence.Jacobi, (-0.27, 0.27), 1e-8),
+    "jac_nn": (orthax.recurrence.Jacobi, (-0.27, -0.27), 1e-8),
+    "geg_pos": (orthax.recurrence.Gegenbauer, (0.1,), 1e-8),
+    "geg_neg": (orthax.recurrence.Gegenbauer, (-0.1,), 1e-6),
+    "lag": (orthax.recurrence.Laguerre, (), 1e-12),
+    "glag_pos": (orthax.recurrence.GeneralizedLaguerre, (2.5,), 1e-8),
+    "glag_neg": (orthax.recurrence.GeneralizedLaguerre, (-0.34,), 1e-8),
+    "herm": (orthax.recurrence.Hermite, (), 1e-12),
+    "herme": (orthax.recurrence.HermiteE, (), 1e-12),
 }
 
 
 @pytest.mark.parametrize("scale", ["monic", "normalized"])
-@pytest.mark.parametrize("name", names)
+@pytest.mark.parametrize("name", recs.keys())
 def test_generate_recurrence(name, scale):
-    rec, args = recs[name]
+    rec, args, tol = recs[name]
     rec1 = rec(*args, scale=scale)
 
     n = 10
@@ -53,7 +58,7 @@ def test_generate_recurrence(name, scale):
 
     nn = np.arange(n)
 
-    assert_allclose(rec1.a(nn), rec2.a(nn), atol=1e-8, rtol=1e-8)
-    assert_allclose(rec1.b(nn), rec2.b(nn), atol=1e-8, rtol=1e-8)
-    assert_allclose(rec1.g(nn), rec2.g(nn), atol=1e-8, rtol=1e-8)
-    assert_allclose(abs(rec1.m(nn)), abs(rec2.m(nn)), atol=1e-8, rtol=1e-8)
+    assert_allclose(rec1.a(nn), rec2.a(nn), atol=tol, rtol=tol)
+    assert_allclose(rec1.b(nn), rec2.b(nn), atol=tol, rtol=tol)
+    assert_allclose(rec1.g(nn), rec2.g(nn), atol=tol, rtol=tol)
+    assert_allclose(abs(rec1.m(nn)), abs(rec2.m(nn)), atol=tol, rtol=tol)


### PR DESCRIPTION
Gegenbauer polynomials are functions of a hyperparameter $\lambda$, and when $\lambda=0$ both the classical normalization factor and leading coefficient are zero, leaving the polynomials effectively undefined for $\lambda=0$. 

In this case the weight function is $(1-x^2)^{-1/2}$, which is the same as Chebyshev polynomials of the first kind, but with a different (non-singular) normalization

This PR adds an error check to ensure that Gengenbauer polynomials are not created with $\lambda=0$ and recommends using Chebyshev polynomials in such a case.

Also fixes an issue with the normalization giving nans when $-1/2 <\lambda < 0$

Resolves #47 