### PR TITLE
build: Support building from sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include versioneer.py
 include orthax/_version.py
+
+include LICENSE README.md pyproject.toml setup.py setup.cfg requirements.txt
+global-exclude __pycache__ *.py[cod] .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=40.8.0", "wheel", "versioneer-518"]
+requires = ["setuptools>=42", "versioneer-518"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,4 +86,3 @@ src_paths=orthax,test
 # https://pypi.org/project/setuptools-declarative-requirements/
 # https://github.com/pypa/setuptools/issues/1951#issuecomment-718094135
 install_requires = requirements.txt
-setup_requires = requirements-dev.txt

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,6 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
 with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
-with open(os.path.join(here, "requirements-dev.txt"), encoding="utf-8") as f:
-    dev_requirements = f.read().splitlines()
-dev_requirements = [
-    foo for foo in dev_requirements if not (foo.startswith("#") or foo.startswith("-r"))
-]
-
 setup(
     name="orthax",
     version=versioneer.get_version(),


### PR DESCRIPTION
As mentioned in Issue https://github.com/f0uriest/orthax/issues/91, current building from `sdists` are broken as orthax`'s requirements are read in from a requirements file

https://github.com/f0uriest/orthax/blob/bea42fb6744e63347bbba8908ed134429477dc90/setup.py#L14-L15

and that `requirements.txt` file is not packaged

https://github.com/f0uriest/orthax/blob/bea42fb6744e63347bbba8908ed134429477dc90/MANIFEST.in#L1-L2.

```console
$ docker run --rm -ti ghcr.io/prefix-dev/pixi:latest 
root@96b06f6262d6:/# pixi global install uv
└── uv: 0.11.3 (installed)
    └─ exposes: uv, uvx
root@96b06f6262d6:/# uv venv
Using CPython 3.14.3
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
root@96b06f6262d6:/# . .venv/bin/activate
(.venv) root@96b06f6262d6:/# uv pip install --no-binary orthax orthax
Resolved 11 packages in 568ms
  x Failed to build `orthax==0.2.8`
  |-> The build backend returned an error
  `-> Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
        File "/root/.cache/uv/builds-v0/.tmp3ORnZU/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/root/.cache/uv/builds-v0/.tmp3ORnZU/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/root/.cache/uv/builds-v0/.tmp3ORnZU/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: '/root/.cache/uv/sdists-v9/pypi/orthax/0.2.8/bJG_ojyvtXZvTmULcrRxL/src/requirements.txt'

      hint: This usually indicates a problem with the package or the build environment.
```

This PR fixes that by ensuring the required packages are include in `setuptools` manifest and removing legacy keywords that are considered deprecated in modern `setuptools`.

We can see that this works now as expected by building the sdist and wheel distributions and then inspecting the sdist

```console
$ rm -rf dist/* *.egg* && uvx --from build pyproject-build
$ python -m tarfile --list dist/*.tar.gz
orthax-0+untagged.203.g3b4499e/ 
orthax-0+untagged.203.g3b4499e/LICENSE 
orthax-0+untagged.203.g3b4499e/MANIFEST.in 
orthax-0+untagged.203.g3b4499e/PKG-INFO 
orthax-0+untagged.203.g3b4499e/README.rst 
orthax-0+untagged.203.g3b4499e/orthax/ 
orthax-0+untagged.203.g3b4499e/orthax/__init__.py 
orthax-0+untagged.203.g3b4499e/orthax/_general.py 
orthax-0+untagged.203.g3b4499e/orthax/_version.py 
orthax-0+untagged.203.g3b4499e/orthax/chebyshev.py 
orthax-0+untagged.203.g3b4499e/orthax/hermite.py 
orthax-0+untagged.203.g3b4499e/orthax/hermite_e.py 
orthax-0+untagged.203.g3b4499e/orthax/laguerre.py 
orthax-0+untagged.203.g3b4499e/orthax/legendre.py 
orthax-0+untagged.203.g3b4499e/orthax/polynomial.py 
orthax-0+untagged.203.g3b4499e/orthax/polyutils.py 
orthax-0+untagged.203.g3b4499e/orthax/recurrence.py 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/ 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/PKG-INFO 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/SOURCES.txt 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/dependency_links.txt 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/requires.txt 
orthax-0+untagged.203.g3b4499e/orthax.egg-info/top_level.txt 
orthax-0+untagged.203.g3b4499e/pyproject.toml 
orthax-0+untagged.203.g3b4499e/requirements.txt 
orthax-0+untagged.203.g3b4499e/setup.cfg 
orthax-0+untagged.203.g3b4499e/setup.py 
orthax-0+untagged.203.g3b4499e/tests/ 
orthax-0+untagged.203.g3b4499e/tests/test_chebyshev.py 
orthax-0+untagged.203.g3b4499e/tests/test_hermite.py 
orthax-0+untagged.203.g3b4499e/tests/test_hermite_e.py 
orthax-0+untagged.203.g3b4499e/tests/test_laguerre.py 
orthax-0+untagged.203.g3b4499e/tests/test_legendre.py 
orthax-0+untagged.203.g3b4499e/tests/test_orth.py 
orthax-0+untagged.203.g3b4499e/tests/test_polynomial.py 
orthax-0+untagged.203.g3b4499e/tests/test_polyutils.py 
orthax-0+untagged.203.g3b4499e/tests/test_recurrence.py 
orthax-0+untagged.203.g3b4499e/versioneer.py
$ python -m tarfile --list dist/*.tar.gz | grep requirements
orthax-0+untagged.203.g3b4499e/requirements.txt
```

We can also install from the sdist to show it is a valid archive now

```console
$ uv venv debug
Using CPython 3.14.2
Creating virtual environment at: debug
Activate with: source debug/bin/activate
$ . debug/bin/activate
$ uv pip install ./dist/*.tar.gz
Using Python 3.14.2 environment at: debug
Resolved 11 packages in 283ms
      Built orthax @ file:///home/feickert/Code/GitHub/forks/orthax/dist/orthax-0+untagged.203.g3b4499e.tar.gz
Prepared 5 packages in 5.81s
Installed 11 packages in 60ms
 + equinox==0.13.6
 + jax==0.9.2
 + jaxlib==0.9.2
 + jaxtyping==0.3.9
 + ml-dtypes==0.5.4
 + numpy==2.4.4
 + opt-einsum==3.4.0
 + orthax==0+untagged.203.g3b4499e (from file:///home/feickert/Code/GitHub/forks/orthax/dist/orthax-0+untagged.203.g3b4499e.tar.gz)
 + scipy==1.17.1
 + typing-extensions==4.15.0
 + wadler-lindig==0.1.7
$ uv pip show orthax
Using Python 3.14.2 environment at: debug
Name: orthax
Version: 0+untagged.203.g3b4499e
Location: /home/feickert/Code/GitHub/forks/orthax/debug/lib/python3.14/site-packages
Requires: equinox, jax, numpy
Required-by:
```

---

* The 'setup_requires' keyword is now considered deprecated in favor of PEP 517/PEP 518 build-system.
   - c.f. https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement
   - c.f. https://peps.python.org/pep-0517/
* Remove wheel from build-system.requires as that is now redundant.
   - c.f. https://learn.scientific-python.org/development/guides/packaging-classic/
* Update setuptools to v42 to conform with modern standards.
* Add requirements.txt to setuptools manifest.